### PR TITLE
Fix 'If-Modified-Since' format string

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -2365,13 +2365,14 @@ def test_get_object_ifmodifiedsince_failed():
     for k in bucket.get_all_keys():
         key = k
 
-    mtime = time.strptime(key.last_modified, '%Y-%m-%dT%H:%M:%S.%fZ')
+    mtime = datetime.datetime.strptime(key.last_modified, '%Y-%m-%dT%H:%M:%S.%fZ')
 
-    after = time.ctime(time.mktime(mtime) + 1)
+    after = mtime + datetime.timedelta(seconds=1)
+    after_str = time.strftime("%a, %d %b %Y %H:%M:%S GMT", after.timetuple())
 
     time.sleep(1)
 
-    e = assert_raises(boto.exception.S3ResponseError, bucket.get_key, 'foo', headers={'If-Modified-Since': after})
+    e = assert_raises(boto.exception.S3ResponseError, bucket.get_key, 'foo', headers={'If-Modified-Since': after_str})
     eq(e.status, 304)
     eq(e.reason, 'Not Modified')
 


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7232
header 'If-Modified-Since' should be a correct HTTP-date.
For example: `Tue, 15 Nov 1994 12:45:26 GMT`;
not `1994-11-15T12:45:26.000Z`.